### PR TITLE
Agregar paquete wrt (benchmark con libcurl)

### DIFF
--- a/packages/wrt/build.sh
+++ b/packages/wrt/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/lavacraft239/Wrt-benchmark
+TERMUX_PKG_DESCRIPTION="Benchmark HTTP/RTMP multi-thread con libcurl y pthread"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Lavacraft239 <santiagomanzolillo@email.com>"
+TERMUX_PKG_VERSION=1.0.0
+TERMUX_PKG_SRCURL=https://github.com/lavacraft239/Wrt-benchmark/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=dc2192f4ed98e74541594da19bb3163f7c288f838b31ba8a380f858db0a0a288
+
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+    make
+}
+
+termux_step_make_install() {
+    install -Dm700 wrt $TERMUX_PREFIX/bin/wrt
+}


### PR DESCRIPTION
Este PR agrega el paquete `wrt`, una herramienta de benchmark multithread que usa libcurl, pthread y soporta HTTP y RTMP. 
Funciona en Termux, soporta múltiples hilos y conexiones, mide latencias y exporta resultados a CSV.

Incluye:
- curl_multi
- barra de progreso
- simulación opcional (-x)
- soporte para ignorar certificados (--insecure)

Tested: ✅ build local exitoso en entorno termux-packages